### PR TITLE
A failing test to reproduce #13

### DIFF
--- a/test/assign.js
+++ b/test/assign.js
@@ -1,0 +1,60 @@
+'use strict';
+
+import {expect} from 'chai';
+import YAWN from '../src/index.js';
+
+describe('doesn\'t throw errors when', ()=> {
+
+  describe('JSON is an object and gets replaced with', ()=> {
+
+    it('a new JSON object with one change', ()=> {
+      let str = `
+        # leading comment
+        foo:
+          bar: Bar
+          baz: Baz
+        # trailing comment`;
+
+      let yawn = new YAWN(str);
+      yawn.json = {
+        foo: {
+          bar: 'New Bar',
+          baz: 'Baz'
+        }
+      };
+
+      expect(yawn.yaml).to.equal(`
+        # leading comment
+        foo:
+          bar: New Bar
+          baz: Baz
+        # trailing comment`);
+    });
+
+    it('a new JSON object with two changes', ()=> {
+      let str = `
+        # leading comment
+        foo:
+          bar: Bar
+          baz: Baz
+        # trailing comment`;
+
+      let yawn = new YAWN(str);
+      yawn.json = {
+        foo: {
+          bar: 'New Bar',
+          baz: 'New Baz'
+        }
+      };
+
+      expect(yawn.yaml).to.equal(`
+        # leading comment
+        foo:
+          bar: New Bar
+          baz: New Baz
+        # trailing comment`);
+    });
+
+  });
+
+});


### PR DESCRIPTION
The "a new JSON object with two changes" test throws a `yaml-js` error:

```
hile scanning a simple key
    on line 5, column 11
  could not find expected ':'
    on line 6, column 9
      at ScannerError.YAMLError [as constructor] (node_modules/yaml-js/lib/errors.js:70:46)
      at ScannerError.MarkedYAMLError [as constructor] (node_modules/yaml-js/lib/errors.js:90:45)
      at new ScannerError (node_modules/yaml-js/lib/scanner.js:23:49)
      at Loader.__dirname.Scanner.Scanner.stale_possible_simple_keys (node_modules/yaml-js/lib/scanner.js:285:17)
      at Loader.__dirname.Scanner.Scanner.need_more_tokens (node_modules/yaml-js/lib/scanner.js:167:12)
      at Loader.__dirname.Scanner.Scanner.check_token (node_modules/yaml-js/lib/scanner.js:114:19)
      at Loader.__dirname.Parser.Parser.parse_block_mapping_key (node_modules/yaml-js/lib/parser.js:421:16)
      at Loader.__dirname.Parser.Parser.check_event (node_modules/yaml-js/lib/parser.js:61:48)
      at Loader.__dirname.Composer.Composer.compose_mapping_node (node_modules/yaml-js/lib/composer.js:248:20)
      at Loader.__dirname.Composer.Composer.compose_node (node_modules/yaml-js/lib/composer.js:160:21)
      at Loader.__dirname.Composer.Composer.compose_mapping_node (node_modules/yaml-js/lib/composer.js:250:27)
      at Loader.__dirname.Composer.Composer.compose_node (node_modules/yaml-js/lib/composer.js:160:21)
      at Loader.__dirname.Composer.Composer.compose_document (node_modules/yaml-js/lib/composer.js:116:19)
      at Loader.__dirname.Composer.Composer.get_single_node (node_modules/yaml-js/lib/composer.js:91:25)
      at __dirname.compose (node_modules/yaml-js/lib/yaml.js:78:20)
      at src/index.js:249:15
      at arrayEach (node_modules/lodash/index.js:1289:13)
      at node_modules/lodash/index.js:3345:13
      at updateMap (src/index.js:208:3)
      at YAWN.set (src/index.js:98:19)
      at Context.<anonymous> (test/assign.js:43:16)
```