### PR TITLE
Fix Vulnerability in Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/yawn.js",
   "dependencies": {
     "js-yaml": "^3.4.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.5",
     "yaml-js": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
As `npm audit` shows:

```
  Low             Prototype Pollution

  Package         lodash

  Patched in      >=4.17.5

  Dependency of   express-gateway

  Path            yawn-yaml > lodash

  More info       https://nodesecurity.io/advisories/577
```