### PR TITLE
fix: comments not preserved on some array items when updating JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yawn-yaml",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "author": "Mohsen Azimi",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,9 @@ export default class YAWN {
     // SEQ_TAG
     // -------------------------------------------------------------------------
     if (ast.tag === SEQ_TAG) {
-      this.yaml = updateSeq(ast, newJson, this.yaml, 0);
+      let json = this.json;
+
+      this.yaml = updateSeq(ast, newJson, json, this.yaml, 0);
     }
 
     // Trim trailing whitespaces
@@ -180,12 +182,17 @@ function getTag(json: any) {
 function updateSeq(
   ast: Node,
   newJson: any[],
+  json: any[],
   yaml: string,
   offset: number
 ): string {
   let values: any[] = load(serialize(ast)) as any[];
   let min: number = Math.min(values.length, newJson.length);
   for (let i: number = 0; i < min; i++) {
+    if (isEqual(json[i], newJson[i])) {
+      continue;
+    }
+
     const newYaml: string = changeArrayElement(
       ast.value[i],
       cleanDump(newJson[i]),
@@ -253,7 +260,7 @@ function updateMap(
       // array value has changed
       if (isArray(newValue)) {
         // recurse
-        const newYaml = updateSeq(valNode, newValue, yaml, offset);
+        const newYaml = updateSeq(valNode, newValue, value, yaml, offset);
         offset = offset + newYaml.length - yaml.length;
         yaml = newYaml;
 

--- a/test/array-comment.test.ts
+++ b/test/array-comment.test.ts
@@ -5,39 +5,27 @@ import dedent from 'dedent';
 describe('Comments on array elements', () => {
   it('preserves comments nested in arrays', () => {
     let str = dedent`
-      customers:
-        - name: some-customer
-          deployment:
-            region: us-east-1 # inline comment
-          id: 12345
+      - name: some-customer # inline comment
+        region: us-east-1
     `;
 
     let yawn = new YAWN(str);
-    yawn.json = {
-      customers: [
-        {
-          name: 'some-customer',
-          deployment: { region: 'us-east-1' },
-          id: 12345,
-        },
-        {
-          name: 'some-other-customer',
-          deployment: { region: 'us-east-1' },
-          id: 54321,
-        },
-      ],
-    };
+    yawn.json = [
+      {
+        name: 'some-customer',
+        region: 'us-east-1',
+      },
+      {
+        name: 'some-other-customer',
+        region: 'us-east-1',
+      },
+    ];
 
     expect(yawn.yaml).toEqual(dedent`
-      customers:
-        - name: some-customer
-          deployment:
-            region: us-east-1 # inline comment
-          id: 12345
-        - name: some-other-customer
-          deployment:
-            region: us-east-1
-          id: 54321
+      - name: some-customer # inline comment
+        region: us-east-1
+      - name: some-other-customer
+        region: us-east-1
     `);
   });
 });

--- a/test/array-comment.test.ts
+++ b/test/array-comment.test.ts
@@ -1,0 +1,43 @@
+import YAWN from '../src';
+
+import dedent from 'dedent';
+
+describe('Comments on array elements', () => {
+  it('preserves comments nested in arrays', () => {
+    let str = dedent`
+      customers:
+        - name: some-customer
+          deployment:
+            region: us-east-1 # inline comment
+          id: 12345
+    `;
+
+    let yawn = new YAWN(str);
+    yawn.json = {
+      customers: [
+        {
+          name: 'some-customer',
+          deployment: { region: 'us-east-1' },
+          id: 12345,
+        },
+        {
+          name: 'some-other-customer',
+          deployment: { region: 'us-east-1' },
+          id: 54321,
+        },
+      ],
+    };
+
+    expect(yawn.yaml).toEqual(dedent`
+      customers:
+        - name: some-customer
+          deployment:
+            region: us-east-1 # inline comment
+          id: 12345
+        - name: some-other-customer
+          deployment:
+            region: us-east-1
+          id: 54321
+    `);
+  });
+});


### PR DESCRIPTION
When updating a YAWN by setting its `.json`, if you set an array to be equal to `[...existing_elements, new_element]`, comments are stripped from the existing elements.

This is because when `updateSeq` is called, it'll call `changeArrayElement` on each element of the array, which updates the node with a `cleanDump`ed version of it. This strips the comments.

This patch changes `updateSeq` to not bother calling `changeArrayElement`, if the existing value matches the new one. I passed a new `json` argument to `updateSeq`, like `updateMap` gets, so we can more easily compare existing nodes to potentially new ones, and only modify the yaml if the array item is changed.

I'm not sure I understand what the `load(serialize(ast))` is doing, so I left it as-is, but I think _maybe_ `updateSeq`'s `values` variable can be replaced with the new `json` argument.

<hr />

I encountered this because we've been using a project that uses YAWN to merge yaml files while preserving comments[0]. The project:
1. generates JSON representations of existing and patch YAMLs
2. merges the JSON representations, using lodash's mergeWith
3. uses YAWN's functionality of setting yawn.json to selectively update the underlying yaml document

This ends up triggering the bug, in cases like the one I added for testing.

[0]: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts#L371